### PR TITLE
Implement quant/dequant and optimize lut memory

### DIFF
--- a/src/lut_utils.hpp
+++ b/src/lut_utils.hpp
@@ -2,16 +2,44 @@
 #include <vector>
 #include <cstddef>
 #include <type_traits>
+#include <cstdlib>    // for posix_memalign, free
+#include <memory>
 
-// =============================================================
-//  ProductLookupTable  —  unified flat-storage LUT
-//  -------------------------------------------------------------
-//  * 只保留 **1‑D 連續記憶體 (table_)**，節省空間。
-//  * 提供 get(w,a) 與 operator()(w,a) => 易用的 2‑D 介面。
-//  * 內建 row‑stride() 方便 SIMD 計算線性 index。
-//  * 同時暴露 data() 讓外部 SIMD kernel 直接 gather。
-// =============================================================
+// 對齊分配器：以 Align 對齊分配
+template<typename T, std::size_t Align>
+struct AlignedAllocator {
+    using value_type      = T;
+    using pointer         = T*;
+    using const_pointer   = const T*;
+    using reference       = T&;
+    using const_reference = const T&;
+    using size_type       = std::size_t;
+    using difference_type = std::ptrdiff_t;
 
+    template<typename U>
+    struct rebind { using other = AlignedAllocator<U, Align>; };
+
+    AlignedAllocator() noexcept {}
+    template<typename U>
+    AlignedAllocator(const AlignedAllocator<U, Align>&) noexcept {}
+
+    bool operator==(AlignedAllocator const&) const noexcept { return true; }
+    bool operator!=(AlignedAllocator const&) const noexcept { return false; }
+
+    pointer allocate(size_type n) {
+        void* ptr = nullptr;
+        if (posix_memalign(&ptr, Align, n * sizeof(T)) != 0)
+            throw std::bad_alloc();
+        return static_cast<pointer>(ptr);
+    }
+
+    void deallocate(pointer p, size_type) noexcept {
+        free(p);
+    }
+};
+
+// lookup table for product of two integers
+// LUT：64-byte 對齊，並將每列 padding 到 8 的倍數
 template <typename W, typename A,
           typename P = std::common_type_t<W, A>>
 class ProductLookupTable {
@@ -21,31 +49,33 @@ public:
     using ProductType    = P;
 
     ProductLookupTable(std::size_t w_range, std::size_t a_range)
-        : w_range_(w_range), a_range_(a_range), table_(w_range * a_range)
+    : w_range_(w_range),
+        a_range_(a_range),
+        padded_a_range_(((a_range + 7) / 8) * 8),
+        table_(w_range * padded_a_range_)  // 用 padding 後的尺寸
     {
         for (std::size_t w = 0; w < w_range_; ++w)
             for (std::size_t a = 0; a < a_range_; ++a)
-                table_[w * a_range_ + a] =
+                table_[w * padded_a_range_ + a] =
                     static_cast<ProductType>(w) * static_cast<ProductType>(a);
     }
 
     // ---- scalar accessors ----
-    inline ProductType get(WeightType w, ActivationType a) const noexcept {
-        return table_[static_cast<std::size_t>(w) * a_range_ + static_cast<std::size_t>(a)];
+    inline ProductType get(W w, A a) const noexcept {
+        return table_[size_t(w) * padded_a_range_ + size_t(a)];
     }
-    inline ProductType operator()(WeightType w, ActivationType a) const noexcept {
+    inline ProductType operator()(W w, A a) const noexcept {
         return get(w, a);
     }
 
     // ---- helpers ----
     const ProductType* data()   const noexcept { return table_.data(); }
-    std::size_t        row_stride() const noexcept { return a_range_; }
+    std::size_t        row_stride() const noexcept { return padded_a_range_; }
     std::size_t        weight_range() const noexcept { return w_range_; }
     std::size_t        activation_range() const noexcept { return a_range_; }
     std::size_t lut_size_bytes() const noexcept { return table_.size() * sizeof(ProductType);}
 
 private:
-    std::size_t              w_range_;
-    std::size_t              a_range_;
-    std::vector<ProductType> table_;   // flat buffer (w * a_range + a)
+    std::size_t w_range_, a_range_, padded_a_range_;
+    std::vector<ProductType, AlignedAllocator<ProductType,64>> table_;   // flat buffer (w * a_range + a)
 };

--- a/src/lut_utils.hpp
+++ b/src/lut_utils.hpp
@@ -42,6 +42,7 @@ public:
     std::size_t        row_stride() const noexcept { return a_range_; }
     std::size_t        weight_range() const noexcept { return w_range_; }
     std::size_t        activation_range() const noexcept { return a_range_; }
+    std::size_t lut_size_bytes() const noexcept { return table_.size() * sizeof(ProductType);}
 
 private:
     std::size_t              w_range_;

--- a/src/quant_utils.hpp
+++ b/src/quant_utils.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+// INT4 量化：fp16_val → uint8_t (低 4 bits)
+inline uint8_t quantize_int4(float fp16_val, float scale, int zero_point = 0) {
+    int q = static_cast<int>(std::round(fp16_val / scale)) + zero_point;
+    q = std::clamp(q, 0, 15);          // INT4 無號 0‥15
+    return static_cast<uint8_t>(q);
+}
+
+// INT4 反量化：uint8_t (低 4 bits) → float
+inline float dequantize_int4(uint8_t q, float scale, int zero_point = 0) {
+    int qi = static_cast<int>(q) - zero_point;
+    return static_cast<float>(qi) * scale;
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -62,6 +62,11 @@ int main() {
 
     ProductLookupTable<uint8_t,uint8_t,int32_t> lut(16,16);
 
+    // lut size and shape
+    std::cout << "> LUT size: " << lut.lut_size_bytes() << " bytes\n";
+    std::cout << "> LUT Shape: (" << lut.weight_range()
+          << ", " << lut.activation_range() << ")\n";
+
     // scalar (if compiled w/o AVX2) or SIMD depending on flag
     auto t2 = std::chrono::high_resolution_clock::now();
     auto C_fast = matmul_lut_fast(Au, Bu, M, K, N, lut);

--- a/tests/test_correctness.cpp
+++ b/tests/test_correctness.cpp
@@ -3,6 +3,7 @@
 #include "../src/matrix.hpp"
 #include "../src/matrix_ops.hpp"
 #include "../src/lut_utils.hpp"
+#include "../src/quant_utils.hpp"
 
 #include <iostream>
 #include <fstream>
@@ -246,9 +247,24 @@ bool run_int4_fast_test(){
 }
 
 
+// 7. Quantization/Dequantization test
+bool run_quant_dequant_test() {
+    std::cout << "Running INT4 quant-dequant test...\n";
+    float scale = 0.25f;       // 假設
+    bool pass = true;
+    for (float v : {0.0f, 1.0f, 2.25f, 3.5f}) {
+        uint8_t q = quantize_int4(v, scale);
+        float   d = dequantize_int4(q, scale);
+        if (std::abs(d - std::round(v/scale)*scale) > 1e-3f) pass = false;
+    }
+    std::cout << (pass ? "Quant-Dequant test PASS\n" : "FAIL\n");
+    return pass;
+}
+
+
 int main() {
     int passed=0;
-    const int total=9;
+    const int total=10;
     if (run_basic_test()) ++passed;
     if (run_negative_test()) ++passed;
     if (run_non_square_test()) ++passed;
@@ -258,6 +274,7 @@ int main() {
     if (run_int4_int16_test()) ++passed;
     if (run_int4_int32_test()) ++passed;
     if(run_int4_fast_test()) ++passed;
+    if (run_quant_dequant_test()) ++passed;
     std::cout << "\nTotal: " << passed << "/" << total << " tests passed.\n";
     return (passed == total ? 0 : 1);
 }


### PR DESCRIPTION
Implemented simple int4 quantization/dequantization, and aligned LUT memory to 64 bytes for SIMD efficiency.