### PR TITLE
GEMM backend mkl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,27 +10,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-     # ---------- Install toolchain ----------
-      - name: Install compiler & deps
-        run: sudo apt-get update && sudo apt-get install -y build-essential g++
-
-      # ---------- Install Intel oneAPI MKL ----------
-      - name: Add Intel oneAPI apt repo
+      - name: Install dependencies
         run: |
-          wget -qO- https://apt.repos.intel.com/oneapi/gpgkey | sudo apt-key add -
-          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneapi.list
-          sudo apt-get update
-          sudo apt-get install -y intel-oneapi-mkl-devel
+          sudo apt-get -q update
+          sudo apt-get -qy install \
+               build-essential g++ \
+               intel-mkl-full python3 python3-pytest
 
-      # ---------- Export MKLROOT so Makefile can find it ----------
-      - name: Set MKLROOT env
-        run: echo "MKLROOT=/opt/intel/oneapi/mkl/latest" >> $GITHUB_ENV
+      - name: Build project
+        run: |
+          make USE_MKL=1
 
-      # ---------- Build ----------
-      - name: Build project (MKL enabled)
-        run: make USE_MKL=1
-
-      # ---------- Run tests ----------
       - name: Run main test
         run: |
           make run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Build project
         run: |
-          make
+          make USE_MKL=1
 
       - name: Run main test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Install dependencies
+     # ---------- Install toolchain ----------
+      - name: Install compiler & deps
         run: sudo apt-get update && sudo apt-get install -y build-essential g++
 
-      - name: Build project
+      # ---------- Install Intel oneAPI MKL ----------
+      - name: Add Intel oneAPI apt repo
         run: |
-          make USE_MKL=1
+          wget -qO- https://apt.repos.intel.com/oneapi/gpgkey | sudo apt-key add -
+          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneapi.list
+          sudo apt-get update
+          sudo apt-get install -y intel-oneapi-mkl-devel
 
+      # ---------- Export MKLROOT so Makefile can find it ----------
+      - name: Set MKLROOT env
+        run: echo "MKLROOT=/opt/intel/oneapi/mkl/latest" >> $GITHUB_ENV
+
+      # ---------- Build ----------
+      - name: Build project (MKL enabled)
+        run: make USE_MKL=1
+
+      # ---------- Run tests ----------
       - name: Run main test
         run: |
           make run

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ CXXFLAGS   := -std=c++17 -O2 -Wall -I./src -march=native
 
 # ---- MKL toggle ----
 ifeq ($(USE_MKL),1)
-    CXXFLAGS += -DUSE_MKL -I$(MKLROOT)/include
-    LDFLAGS  += -L$(MKLROOT)/lib -Wl,--no-as-needed
-    LDLIBS   += -lmkl_rt
+	MKL_INC := /usr/include/mkl
+	MKL_LIBDIR := /usr/lib/x86_64-linux-gnu
+	CXXFLAGS += -DUSE_MKL -I$(MKL_INC)
+	LDLIBS   += -Wl,--no-as-needed -L$(MKL_LIBDIR) -lmkl_rt -lpthread -lm -ldl
 endif
 # --------------------
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 CXX        := g++
 CXXFLAGS   := -std=c++17 -O2 -Wall -I./src -march=native
 
+# ---- MKL toggle ----
+ifeq ($(USE_MKL),1)
+    CXXFLAGS += -DUSE_MKL -I$(MKLROOT)/include
+    LDFLAGS  += -L$(MKLROOT)/lib -Wl,--no-as-needed
+    LDLIBS   += -lmkl_rt
+endif
+# --------------------
+
+
 SRC_DIR    := src
 TEST_DIR   := tests
 BUILD_DIR  := build
@@ -30,11 +39,11 @@ $(BUILD_DIR):
 
 # build main
 $(TARGET_MAIN): $(TEST_SRC) $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(TEST_SRC) -o $(TARGET_MAIN)
+	$(CXX) $(CXXFLAGS) $(TEST_SRC) -o $(TARGET_MAIN) $(LDFLAGS) $(LDLIBS)
 
 # build correctness suite
 $(TARGET_CORR): $(CORR_SRC) $(HEADERS)
-	$(CXX) $(CXXFLAGS) $(CORR_SRC) -o $(TARGET_CORR)
+	$(CXX) $(CXXFLAGS) $(CORR_SRC) -o $(TARGET_CORR) $(LDFLAGS) $(LDLIBS)
 
 run: all
 	./$(TARGET_MAIN)

--- a/src/gemm_engine.hpp
+++ b/src/gemm_engine.hpp
@@ -1,0 +1,23 @@
+#include <iostream>
+#include <stdexcept>
+#include "matrix.hpp"
+
+
+enum class Backend {
+    Naive,
+    LUT,
+    MKL
+};
+
+struct GemmEngine {
+    Backend backend;
+
+    template<typename T>
+    Matrix<T> matmul(const Matrix<T>& A, const Matrix<T>& B) const {
+        switch (backend) {
+        case Backend::Naive: return matmul(A, B);
+        case Backend::MKL:   return matmul_mkl(A, B);
+        default: throw std::runtime_error("Unsupported backend");
+        }
+    }
+};

--- a/src/matrix.hpp
+++ b/src/matrix.hpp
@@ -22,6 +22,7 @@ public:
         data_.resize(total_units);
     }
 
+    /* ------------ element access ------------ */
     T at(size_t r, size_t c) const {
         size_t lin = LayoutPolicy::index(r, c, rows_, cols_);
         size_t unit_idx = lin / EPU;
@@ -36,8 +37,29 @@ public:
         StoragePolicy::set(data_[unit_idx], value, offset);
     }
 
+    /* ------------ shape ------------ */
     size_t rows() const { return rows_; }
     size_t cols() const { return cols_; }
+
+    /* ------------ raw pointer (PlainStorage only) ------------ */
+    template<
+        typename U = StoragePolicy,
+        std::enable_if_t<
+            std::is_same_v<U, PlainStorage<T>> && U::entries_per_unit == 1,
+            int> = 0>
+    T* data() {                                   // non‑const
+        return reinterpret_cast<T*>(data_.data());
+    }
+
+    template<
+        typename U = StoragePolicy,
+        std::enable_if_t<
+            std::is_same_v<U, PlainStorage<T>> && U::entries_per_unit == 1,
+            int> = 0>
+    const T* data() const {                       // const
+        return reinterpret_cast<const T*>(data_.data());
+    }
+
 
 private:
     size_t rows_, cols_;

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -85,10 +85,9 @@ int main() {
     // === MKL float GEMM (row‑major) ===
     std::cout << "\n==== MKL (float) ====\n";
     using F32R = Matrix<float, RowMajor, PlainStorage<float>>;
-    using F32C = Matrix<float, ColMajor, PlainStorage<float>>;
 
     F32R A_f(M, K);
-    F32C B_f(K, N);
+    F32R B_f(K, N);
 
     // 將 int baseline 轉 float，方便對照
     for (int i=0;i<M;++i)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -80,5 +80,34 @@ int main() {
     std::cout << std::chrono::duration<double,std::milli>(t3-t2).count()
               << " ms\n";
 
+
+#ifdef USE_MKL
+    // === MKL float GEMM (row‑major) ===
+    std::cout << "\n==== MKL (float) ====\n";
+    using F32R = Matrix<float, RowMajor, PlainStorage<float>>;
+    using F32C = Matrix<float, ColMajor, PlainStorage<float>>;
+
+    F32R A_f(M, K);
+    F32C B_f(K, N);
+
+    // 將 int baseline 轉 float，方便對照
+    for (int i=0;i<M;++i)
+        for (int k=0;k<K;++k)
+            A_f.set(i,k, static_cast<float>(A_i.at(i,k)));
+
+    for (int k=0;k<K;++k)
+        for (int j=0;j<N;++j)
+            B_f.set(k,j, static_cast<float>(B_i.at(k,j)));
+
+    auto t4 = std::chrono::high_resolution_clock::now();
+    auto C_mkl = matmul_mkl(A_f, B_f);
+    auto t5 = std::chrono::high_resolution_clock::now();
+
+    std::cout << "MKL sgemm: "
+            << std::chrono::duration<double,std::milli>(t5-t4).count()
+            << " ms\n";
+#endif
+          
+
     return 0;
 }

--- a/tests/test_correctness.cpp
+++ b/tests/test_correctness.cpp
@@ -261,6 +261,29 @@ bool run_quant_dequant_test() {
     return pass;
 }
 
+// 8. MKL test
+#ifdef USE_MKL
+// 8. MKL test
+bool run_mkl_test() {
+    std::cout << "Running MKL test...\n";
+
+    Matrix<float, RowMajor, PlainStorage<float>> A(2,3), B(3,2);
+    for (int i=0; i<2; ++i) for (int j=0; j<3; ++j) A.set(i,j,i+j+1);
+    for (int i=0; i<3; ++i) for (int j=0; j<2; ++j) B.set(i,j,i+j+1);
+
+    auto C = matmul_mkl(A,B);
+
+    Matrix<float, RowMajor, PlainStorage<float>> expected(2,2);
+    expected.set(0,0,30); expected.set(0,1,36);
+    expected.set(1,0,66); expected.set(1,1,78);
+
+    bool pass = check_equal(C, expected);
+    std::cout << (pass ? "MKL test PASS\n" : "MKL test FAIL\n");
+    return pass;
+}
+#endif  // USE_MKL
+
+
 
 int main() {
     int passed=0;
@@ -275,6 +298,10 @@ int main() {
     if (run_int4_int32_test()) ++passed;
     if(run_int4_fast_test()) ++passed;
     if (run_quant_dequant_test()) ++passed;
+    #ifdef USE_MKL
+        ++total;                  // 只有啟用 MKL 才加總數
+        if (run_mkl_test()) ++passed;
+    #endif
     std::cout << "\nTotal: " << passed << "/" << total << " tests passed.\n";
     return (passed == total ? 0 : 1);
 }

--- a/tests/test_correctness.cpp
+++ b/tests/test_correctness.cpp
@@ -274,8 +274,8 @@ bool run_mkl_test() {
     auto C = matmul_mkl(A,B);
 
     Matrix<float, RowMajor, PlainStorage<float>> expected(2,2);
-    expected.set(0,0,30); expected.set(0,1,36);
-    expected.set(1,0,66); expected.set(1,1,78);
+    expected.set(0,0,14); expected.set(0,1,20);
+    expected.set(1,0,20); expected.set(1,1,29);
 
     bool pass = check_equal(C, expected);
     std::cout << (pass ? "MKL test PASS\n" : "MKL test FAIL\n");

--- a/tests/test_correctness.cpp
+++ b/tests/test_correctness.cpp
@@ -287,7 +287,7 @@ bool run_mkl_test() {
 
 int main() {
     int passed=0;
-    const int total=10;
+    int total=10;
     if (run_basic_test()) ++passed;
     if (run_negative_test()) ++passed;
     if (run_non_square_test()) ++passed;


### PR DESCRIPTION
This PR adds MKL support via `matmul_mkl()` in matrix_ops.hpp, with a `Matrix::data()` accessor for raw buffer access. `USE_MKL=1` enables MKL in the build. A new correctness test (run_mkl_test) and MKL timing in main.cpp are also included.