### PR TITLE
Speedup Lut-gemm for issue #30

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,19 +48,19 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 # build main
-$(TARGET_MAIN): $(BUILD_DIR) $(TEST_SRC) $(HEADERS)
+$(TARGET_MAIN): $(TEST_SRC) $(HEADERS)
 	$(CXX) $(CXXFLAGS) $(TEST_SRC) -o $(TARGET_MAIN) $(LDFLAGS) $(LDLIBS)
 
 # build correctness suite
-$(TARGET_CORR): $(BUILD_DIR) $(CORR_SRC) $(HEADERS)
+$(TARGET_CORR):  $(CORR_SRC) $(HEADERS)
 	$(CXX) $(CXXFLAGS) $(CORR_SRC) -o $(TARGET_CORR) $(LDFLAGS) $(LDLIBS)
 
 # build matrix ops test
-$(TARGET_MATRIX_OPS): $(BUILD_DIR) $(MATRIX_OPS_SRC) $(HEADERS)
+$(TARGET_MATRIX_OPS): $(MATRIX_OPS_SRC) $(HEADERS)
 	$(CXX) $(CXXFLAGS) -pthread $(MATRIX_OPS_SRC) -o $(TARGET_MATRIX_OPS) $(LDFLAGS) $(LDLIBS)
 
 # build pybind11 module
-mpgemm$(PYEXT): $(BUILD_DIR) src/bindings.cpp $(HEADERS)
+mpgemm$(PYEXT):  src/bindings.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) $(PYBIND11_INC) -fPIC -shared src/bindings.cpp -o $@ $(LDFLAGS) $(LDLIBS)
 
 # run pytest

--- a/src/matrix_ops.hpp
+++ b/src/matrix_ops.hpp
@@ -6,6 +6,8 @@
 #include <type_traits>
 #include <vector>
 #include <immintrin.h>
+#include <thread>
+#include <mutex>
 
 // =============================================================
 //  Helper: unpack a Matrix<> that uses Int4Storage into a
@@ -29,82 +31,57 @@ std::vector<uint8_t> unpack_int4(const Mat4& M)
 }
 
 // =============================================================
-//  Naive reference GEMM (kept unchanged for correctness checks)
+//  High-performance parallel GEMM implementation
+//  Supports any numeric type through templates
 // =============================================================
 
 template<typename MA, typename MB>
-auto matmul(const MA& A, const MB& B)
+auto matmul(const MA& A, const MB& B, size_t num_threads = 4)
 {
     using T = decltype(A.at(0, 0));
     static_assert(std::is_same_v<T, decltype(B.at(0, 0))>, "Element types must match");
 
     size_t M = A.rows(), K = A.cols(), N = B.cols();
     Matrix<T, RowMajor, PlainStorage<T>> C(M, N);
+    std::vector<std::thread> threads;
 
-    for (size_t i = 0; i < M; ++i)
-        for (size_t k = 0; k < K; ++k) {
-            T a = A.at(i, k);
-            for (size_t j = 0; j < N; ++j)
-                C.set(i, j, C.at(i, j) + a * B.at(k, j));
-        }
-    return C;
-}
+    // 計算每個執行緒處理的行數
+    size_t rows_per_thread = (M + num_threads - 1) / num_threads;
 
-// =============================================================
-//  High‑speed LUT GEMM — expects *unpacked* uint8 buffers.
-//  * Au shape: M × K  contiguous
-//  * Bu shape: K × N  contiguous
-//  Works with or without AVX2 (scalar fallback).
-// =============================================================
+    // 為每個執行緒分配工作
+    for (size_t t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&, t]() {
+            size_t start_row = t * rows_per_thread;
+            size_t end_row = std::min(start_row + rows_per_thread, M);
 
-auto matmul_lut_fast(const std::vector<uint8_t>& Au,
-                      const std::vector<uint8_t>& Bu,
-                      size_t M, size_t K, size_t N,
-                      const ProductLookupTable<uint8_t, uint8_t, int32_t>& lut)
-{
-    const int32_t* lut_ptr = lut.data();
-    const int32_t  stride  = static_cast<int32_t>(lut.row_stride());
+            // 為每個執行緒創建局部結果矩陣
+            Matrix<T, RowMajor, PlainStorage<T>> local_C(M, N);
 
-#if defined(__AVX2__)
-    const __m256i vstride = _mm256_set1_epi32(stride);
-#endif
-
-    Matrix<int32_t, RowMajor, PlainStorage<int32_t>> C(M, N);
-
-    for (size_t i = 0; i < M; ++i) {
-        const uint8_t* rowA = &Au[i * K];
-        for (size_t j = 0; j < N; ++j) {
-            int32_t acc = 0;
-            size_t k = 0;
-
-#if defined(__AVX2__)
-            // --- AVX2: process 8 elements (k dimension) per iteration ---
-            for (; k + 7 < K; k += 8) {
-                // load 8 uint8 from A row / B column (row‑major & col‑major buffers)
-                __m128i w8 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(rowA + k));
-                __m128i a8 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&Bu[k * N + j]));
-
-                __m256i w32 = _mm256_cvtepu8_epi32(w8);
-                __m256i a32 = _mm256_cvtepu8_epi32(a8);
-                __m256i idx = _mm256_add_epi32(_mm256_mullo_epi32(w32, vstride), a32);
-                __m256i vals = _mm256_i32gather_epi32(lut_ptr, idx, 4);
-
-                // horizontal sum of 8 lanes
-                __m128i low  = _mm256_castsi256_si128(vals);
-                __m128i high = _mm256_extracti128_si256(vals, 1);
-                __m128i sum  = _mm_add_epi32(low, high);
-                sum = _mm_hadd_epi32(sum, sum);
-                sum = _mm_hadd_epi32(sum, sum);
-                acc += _mm_cvtsi128_si32(sum);
+            for (size_t i = start_row; i < end_row; ++i) {
+                for (size_t k = 0; k < K; ++k) {
+                    T a = A.at(i, k);
+                    for (size_t j = 0; j < N; ++j) {
+                        local_C.set(i, j, local_C.at(i, j) + a * B.at(k, j));
+                    }
+                }
             }
-#endif
-            // --- scalar remainder (or full loop if no AVX2) ---
-            for (; k < K; ++k)
-                acc += lut_ptr[rowA[k] * stride + Bu[k * N + j]];
 
-            C.set(i, j, acc);
-        }
+            // 合併結果
+            static std::mutex mtx;
+            std::lock_guard<std::mutex> lock(mtx);
+            for (size_t i = start_row; i < end_row; ++i) {
+                for (size_t j = 0; j < N; ++j) {
+                    C.set(i, j, C.at(i, j) + local_C.at(i, j));
+                }
+            }
+        });
     }
+
+    // 等待所有執行緒完成
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
     return C;
 }
 
@@ -150,3 +127,113 @@ Matrix<T> matmul_mkl(const Matrix<T>& A, const Matrix<T>& B) {
     return C;
 }
 #endif
+
+// =============================================================
+//  High‑speed LUT GEMM — expects *unpacked* uint8 buffers.
+//  * Au shape: M × K  contiguous
+//  * Bu shape: K × N  contiguous
+//  Works with or without AVX2 (scalar fallback).
+// =============================================================
+
+auto matmul_lut_fast(const std::vector<uint8_t>& Au,
+                    const std::vector<uint8_t>& Bu,
+                    size_t M, size_t K, size_t N,
+                    const ProductLookupTable<uint8_t, uint8_t, int32_t>& lut,
+                    size_t block_size = 64,  // 增加區塊大小以減少同步開銷
+                    size_t num_threads = 4)
+{
+    const int32_t* lut_ptr = lut.data();
+    const int32_t stride = static_cast<int32_t>(lut.row_stride());
+    Matrix<int32_t, RowMajor, PlainStorage<int32_t>> C(M, N);
+    std::vector<std::thread> threads;
+    std::mutex mtx;
+
+    // 預取 LUT 到 L1 cache
+    for (size_t i = 0; i < 16; ++i) {
+        for (size_t j = 0; j < 16; ++j) {
+            _mm_prefetch(reinterpret_cast<const char*>(&lut_ptr[i * stride + j]), _MM_HINT_T0);
+        }
+    }
+
+    // 計算每個執行緒處理的行數
+    size_t rows_per_thread = (M + num_threads - 1) / num_threads;
+
+    // 為每個執行緒分配工作
+    for (size_t t = 0; t < num_threads; ++t) {
+        threads.emplace_back([&, t]() {
+            size_t start_row = t * rows_per_thread;
+            size_t end_row = std::min(start_row + rows_per_thread, M);
+
+            // 為每個執行緒創建局部結果矩陣
+            Matrix<int32_t, RowMajor, PlainStorage<int32_t>> local_C(M, N);
+
+            // 分塊處理
+            for (size_t i = start_row; i < end_row; i += block_size) {
+                size_t i_end = std::min(i + block_size, end_row);
+                
+                for (size_t j = 0; j < N; j += block_size) {
+                    size_t j_end = std::min(j + block_size, N);
+                    
+                    for (size_t k = 0; k < K; k += block_size) {
+                        size_t k_end = std::min(k + block_size, K);
+                        
+                        // 處理當前區塊
+                        for (size_t ii = i; ii < i_end; ++ii) {
+                            const uint8_t* rowA = &Au[ii * K];
+                            
+                            for (size_t jj = j; jj < j_end; ++jj) {
+                                int32_t acc = 0;
+                                
+#if defined(__AVX2__)
+                                // 使用 AVX2 處理 8 個元素
+                                for (size_t kk = k; kk + 7 < k_end; kk += 8) {
+                                    __m128i w8 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(rowA + kk));
+                                    __m128i a8 = _mm_loadl_epi64(reinterpret_cast<const __m128i*>(&Bu[kk * N + jj]));
+                                    
+                                    __m256i w32 = _mm256_cvtepu8_epi32(w8);
+                                    __m256i a32 = _mm256_cvtepu8_epi32(a8);
+                                    __m256i idx = _mm256_add_epi32(_mm256_mullo_epi32(w32, _mm256_set1_epi32(stride)), a32);
+                                    
+                                    // 預取下一個 LUT 值
+                                    _mm_prefetch(reinterpret_cast<const char*>(&lut_ptr[_mm256_extract_epi32(idx, 0)]), _MM_HINT_T0);
+                                    
+                                    __m256i vals = _mm256_i32gather_epi32(lut_ptr, idx, 4);
+                                    
+                                    // 水平加總
+                                    __m128i low = _mm256_castsi256_si128(vals);
+                                    __m128i high = _mm256_extracti128_si256(vals, 1);
+                                    __m128i sum = _mm_add_epi32(low, high);
+                                    sum = _mm_hadd_epi32(sum, sum);
+                                    sum = _mm_hadd_epi32(sum, sum);
+                                    acc += _mm_cvtsi128_si32(sum);
+                                }
+#endif
+                                // 處理剩餘元素
+                                for (size_t kk = k + ((k_end - k) & ~7); kk < k_end; ++kk) {
+                                    acc += lut_ptr[rowA[kk] * stride + Bu[kk * N + jj]];
+                                }
+                                
+                                local_C.set(ii, jj, local_C.at(ii, jj) + acc);
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 合併結果
+            std::lock_guard<std::mutex> lock(mtx);
+            for (size_t i = start_row; i < end_row; ++i) {
+                for (size_t j = 0; j < N; ++j) {
+                    C.set(i, j, C.at(i, j) + local_C.at(i, j));
+                }
+            }
+        });
+    }
+
+    // 等待所有執行緒完成
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    return C;
+}

--- a/tests/test_matrix_ops.cpp
+++ b/tests/test_matrix_ops.cpp
@@ -1,0 +1,85 @@
+#include "matrix_ops.hpp"
+#include "matrix.hpp"
+#include <vector>
+#include <chrono>
+#include <iostream>
+
+void run_float() {
+    const size_t M = 1024;
+    const size_t K = 1024;
+    const size_t N = 1024;
+    
+    // 建立 float 矩陣
+    Matrix<float, RowMajor, PlainStorage<float>> A_float(M, K);
+    Matrix<float, RowMajor, PlainStorage<float>> B_float(K, N);
+    
+    // 初始化矩陣
+    for (size_t i = 0; i < M; ++i) {
+        for (size_t j = 0; j < K; ++j) {
+            A_float.set(i, j, static_cast<float>(i + j) / 1000.0f);
+        }
+    }
+    
+    for (size_t i = 0; i < K; ++i) {
+        for (size_t j = 0; j < N; ++j) {
+            B_float.set(i, j, static_cast<float>(i * j) / 1000.0f);
+        }
+    }
+    
+    auto start = std::chrono::high_resolution_clock::now();
+    auto result = matmul(A_float, B_float);
+    auto end = std::chrono::high_resolution_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    std::cout << "Float time: " << time << " ms\n";
+}
+
+void run_lut() {
+    const size_t M = 1024;
+    const size_t K = 1024;
+    const size_t N = 1024;
+    
+    // 建立 int4 矩陣
+    Matrix<uint8_t, RowMajor, Int4Storage> A_int4(M, K);
+    Matrix<uint8_t, RowMajor, Int4Storage> B_int4(K, N);
+    
+    // 初始化矩陣
+    for (size_t i = 0; i < M; ++i) {
+        for (size_t j = 0; j < K; ++j) {
+            A_int4.set(i, j, (i + j) % 16);
+        }
+    }
+    
+    for (size_t i = 0; i < K; ++i) {
+        for (size_t j = 0; j < N; ++j) {
+            B_int4.set(i, j, (i * j) % 16);
+        }
+    }
+    
+    // 建立查找表
+    ProductLookupTable<uint8_t, uint8_t, int32_t> lut(16, 16);
+    
+    auto start = std::chrono::high_resolution_clock::now();
+    auto result = matmul_lut_fast(unpack_int4(A_int4), unpack_int4(B_int4), M, K, N, lut);
+    auto end = std::chrono::high_resolution_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count();
+    std::cout << "LUT time: " << time << " ms\n";
+}
+
+int main(int argc, char* argv[]) {
+    if (argc != 2) {
+        std::cout << "Usage: " << argv[0] << " [float|lut]\n";
+        return 1;
+    }
+    
+    std::string mode = argv[1];
+    if (mode == "float") {
+        run_float();
+    } else if (mode == "lut") {
+        run_lut();
+    } else {
+        std::cout << "Invalid mode. Use 'float' or 'lut'\n";
+        return 1;
+    }
+    
+    return 0;
+} 


### PR DESCRIPTION
Based on the investigation in ISSUE #30 ,  it was found that LUT GEMM suffers from high L1 cache miss rates, making memory latency the performance bottleneck rather than computation. Several optimizations were applied, such as prefetching the LUT into L1 cache and tiling the matrices to avoid loading overly large chunks that cause cache misses. Additionally, multithreading was introduced to further improve performance. The original naive implementation was also updated to support multithreading, making it easier to compare performance under a fixed thread count.
Lastly, `tests/test_matrix_ops.cpp` was added to help dump the assembly of both the naive (float) and LUT GEMM versions for comparison.