### PR TITLE
Feature/int4 lut gemm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX        := g++
-CXXFLAGS   := -std=c++17 -O2 -Wall -I./src -march=native
+CXXFLAGS   := -std=c++17 -O2 -Wall -I./src -march=native -fopenmp
 
 PYBIND11_INC := $(shell python3 -m pybind11 --includes)
 PYEXT := $(shell python3-config --extension-suffix)
@@ -12,6 +12,10 @@ ifeq ($(USE_MKL),1)
 	CXXFLAGS += -DUSE_MKL -I$(MKL_INC)
 	LDLIBS   += -Wl,--no-as-needed -L$(MKL_LIBDIR) -lmkl_rt -lpthread -lm -ldl
 endif
+# --------------------
+
+# ---- OpenMP toggle ----
+LDLIBS   += -lgomp
 # --------------------
 
 

--- a/doc/proposal.md
+++ b/doc/proposal.md
@@ -11,7 +11,7 @@ common precision, as hardware lacks native support for mixed-precision matrix
 multiplication (mpGEMM). Some recent research suggests using lookup tables 
 (LUTs) to replace dequantization, further reducing computational overhead.
 
-![LUT](./img/lut.png)
+![LUT](../img/lut.png)
 
 ## Problem to Solve
 

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -18,12 +18,10 @@ def main():
 
     # 生成随机 INT4 权重（-8 到 +7）
     weights = rng.integers(-8, 8, size=(M, K), dtype=np.int8)
-    print("weights:")
-    print(weights)
+
     # 將有符號 int4 轉換為無符號表示
     weights_unsigned = np.where(weights < 0, weights + 16, weights).astype(np.uint8)
-    print("weights_unsigned:")
-    print(weights_unsigned)
+
     # 生成随机 FP16 激活（使用標準正態分佈）
     activations = rng.standard_normal(size=(K, N)).astype(np.float16)
     # 随机 bias（FP32，範圍也限制在合理範圍內）
@@ -37,15 +35,13 @@ def main():
     # === 1. 基准参考输出 ===
     gemm_ref = mpgemm.Engine("naive")
     ref_flat = gemm_ref.matmul(w_flat, a_flat, M, K, N)
-    print("ref_flat:")
-    print(ref_flat)
+
 
     # === 2. LUT 后端输出 ===
     gemm_lut = mpgemm.Engine("lut")
     gemm_lut.generate_lut(bit_width=4)
     out_flat = gemm_lut.matmul(w_flat, a_flat, M, K, N)
-    print("out_flat:")
-    print(out_flat)
+
 
     # === 3. 后处理示例 ===
     out_biased = gemm_lut.add_bias(out_flat, M, N, bias_list)

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -16,15 +16,18 @@ def main():
     # 随机数生成器
     rng = np.random.default_rng(2025)
 
-    # 生成随机 INT4 权重（0-15）
-    weights = rng.integers(0, 16, size=(M, K), dtype=np.uint8)
+    # 生成随机 INT4 权重（-8 到 +7）
+    weights = rng.integers(-8, 8, size=(M, K), dtype=np.int8)
+    # 將有符號 int4 轉換為無符號表示
+    weights_unsigned = np.where(weights < 0, weights + 16, weights).astype(np.uint8)
+    
     # 生成随机 FP16 激活
     activations = rng.standard_normal(size=(K, N)).astype(np.float16)
     # 随机 bias（FP32）
     bias = rng.standard_normal(size=N).astype(np.float32)
 
     # 扁平化并转为 Python 列表
-    w_flat = weights.flatten().tolist()
+    w_flat = weights_unsigned.flatten().tolist()
     a_flat = activations.flatten().astype(float).tolist()
     bias_list = bias.tolist()
 

--- a/src/gemm_engine.hpp
+++ b/src/gemm_engine.hpp
@@ -55,10 +55,12 @@ public:
         switch (backend) {
         case Backend::Naive: {
             Matrix<int,RowMajor,PlainStorage<int>> Wi(M, K), Ai(K, N);
-            // 填充 Wi, Ai
+            // 填充 Wi, Ai，將 uint8_t 轉換為有符號 int
             for (int i = 0; i < M; ++i)
-                for (int j = 0; j < K; ++j)
-                    Wi.set(i, j, (int)Wflat[size_t(i)*K + j]);
+                for (int j = 0; j < K; ++j) {
+                    int val = Wflat[size_t(i)*K + j];
+                    Wi.set(i, j, val < 8 ? val : val - 16);  // 轉換為有符號
+                }
             for (int i = 0; i < K; ++i)
                 for (int j = 0; j < N; ++j)
                     Ai.set(i, j, (int)std::lround(Aflat[size_t(i)*N + j]));
@@ -77,11 +79,15 @@ public:
                 for (int j = 0; j < K; ++j)
                     Wq.set(i,j, Wflat[size_t(i)*K + j]);
             auto Wu = unpack_int4(Wq);
-            // 把 Activation floats 截断、cast 为 uint8 索引
+            // 把 Activation floats 截断、cast 为 uint8 索引，並轉換為有符號
             std::vector<uint8_t> Au(size_t(K)*N);
             for (int i = 0; i < K; ++i)
-                for (int j = 0; j < N; ++j)
-                    Au[size_t(i)*N + j] = uint8_t(std::lround(Aflat[size_t(i)*N + j]));
+                for (int j = 0; j < N; ++j) {
+                    float val = Aflat[size_t(i)*N + j];
+                    int q = std::lround(val);
+                    q = std::clamp(q, -8, 7);  // 限制在有符號 int4 範圍
+                    Au[size_t(i)*N + j] = uint8_t(q < 0 ? q + 16 : q);
+                }
             auto Ci = matmul_lut_fast(Wu, Au, M, K, N, *lut);
             for (int i = 0; i < M; ++i)
                 for (int j = 0; j < N; ++j)

--- a/src/gemm_engine.hpp
+++ b/src/gemm_engine.hpp
@@ -26,9 +26,9 @@ public:
       : lut(nullptr)
     {
         if      (backend_str == "naive")   backend = Backend::Naive;
-        else if (backend_str == "lut")         backend = Backend::LUT;
+        else if (backend_str == "lut")     backend = Backend::LUT;
 #ifdef USE_MKL
-        else if (backend_str == "mkl")         backend = Backend::MKL;
+        else if (backend_str == "mkl")     backend = Backend::MKL;
 #endif
         else throw std::invalid_argument("Unknown backend: " + backend_str);
     }
@@ -79,15 +79,19 @@ public:
                 for (int j = 0; j < K; ++j)
                     Wq.set(i,j, Wflat[size_t(i)*K + j]);
             auto Wu = unpack_int4(Wq);
-            // 把 Activation floats 截断、cast 为 uint8 索引，並轉換為有符號
+            
+            // 把 Activation floats 截断、cast 为 uint8 索引
             std::vector<uint8_t> Au(size_t(K)*N);
             for (int i = 0; i < K; ++i)
                 for (int j = 0; j < N; ++j) {
                     float val = Aflat[size_t(i)*N + j];
+                    // 將浮點數轉換為有符號 int4 範圍
                     int q = std::lround(val);
                     q = std::clamp(q, -8, 7);  // 限制在有符號 int4 範圍
+                    // 轉換為無符號表示
                     Au[size_t(i)*N + j] = uint8_t(q < 0 ? q + 16 : q);
                 }
+            
             auto Ci = matmul_lut_fast(Wu, Au, M, K, N, *lut);
             for (int i = 0; i < M; ++i)
                 for (int j = 0; j < N; ++j)

--- a/src/lut_utils.hpp
+++ b/src/lut_utils.hpp
@@ -4,6 +4,8 @@
 #include <type_traits>
 #include <cstdlib>    // for posix_memalign, free
 #include <memory>
+#include <limits>
+#include <iostream>
 
 // 對齊分配器：以 Align 對齊分配
 template<typename T, std::size_t Align>
@@ -40,42 +42,97 @@ struct AlignedAllocator {
 
 // lookup table for product of two integers
 // LUT：64-byte 對齊，並將每列 padding 到 8 的倍數
-template <typename W, typename A,
-          typename P = std::common_type_t<W, A>>
+template <typename W, typename A, typename P = std::common_type_t<W, A>>
 class ProductLookupTable {
 public:
     using WeightType     = W;
     using ActivationType = A;
     using ProductType    = P;
 
-    ProductLookupTable(std::size_t w_range, std::size_t a_range)
-    : w_range_(w_range),
-        a_range_(a_range),
-        padded_a_range_(((a_range + 7) / 8) * 8),
-        table_(w_range * padded_a_range_)  // 用 padding 後的尺寸
+    // 建構内部初始化，接受權重量化層數與 activation 長度
+    ProductLookupTable(std::size_t weight_levels, std::size_t a_range)
+        : weight_levels_(weight_levels),
+          a_range_(a_range),
+          padded_a_range_(((a_range + 7) / 8) * 8),
+          table_(weight_levels * padded_a_range_)
     {
-        for (std::size_t w = 0; w < w_range_; ++w)
-            for (std::size_t a = 0; a < a_range_; ++a)
-                table_[w * padded_a_range_ + a] =
-                    static_cast<ProductType>(w) * static_cast<ProductType>(a);
+        // Default initialization: scalar LUT for weight × activation (raw) values
+        for (std::size_t w = 0; w < weight_levels_; ++w) {
+            int signed_w = static_cast<int>(w < (weight_levels_/2) ? w : w - weight_levels_);
+            P* row_ptr = &table_[w * padded_a_range_];
+            for (std::size_t a = 0; a < a_range_; ++a) {
+                // Activation index a treated as raw ActivationType
+                ActivationType act_val = static_cast<ActivationType>(a);
+                int64_t prod = static_cast<int64_t>(signed_w) * static_cast<int64_t>(act_val);
+                // Saturate to ProductType range
+                if (prod > std::numeric_limits<P>::max()) prod = std::numeric_limits<P>::max();
+                else if (prod < std::numeric_limits<P>::min()) prod = std::numeric_limits<P>::min();
+                row_ptr[a] = static_cast<P>(prod);
+            }
+            // padding region left uninitialized
+        }
     }
 
-    // ---- scalar accessors ----
-    inline ProductType get(W w, A a) const noexcept {
-        return table_[size_t(w) * padded_a_range_ + size_t(a)];
+    /**
+     * fill_from_activation:
+     * 根據輸入的 activation row (act_row, 長度 = a_range_)，
+     * 為所有 weight level 預先計算並填充查表數據：
+     * 對於每個 weight w (0..weight_levels_-1)，
+     *   1. 轉為有符號值 signed_w
+     *   2. 遍歷所有 activation 值 act_row[a]
+     *   3. 計算 signed_w * act_row[a]，並做飽和處理
+     *   4. 存入 table_[w * padded_a_range_ + a]
+     *
+     * 這樣，後續 matmul 可直接對每個 weight lookup 整列乘積向量，
+     * 而不需即時計算乘法。
+     */
+    void fill_from_activation(const ActivationType* act_row) {
+        for (std::size_t w = 0; w < weight_levels_; ++w) {
+            int signed_w = static_cast<int>(w < (weight_levels_/2) ? w : w - weight_levels_);
+            P* row_ptr = &table_[w * padded_a_range_];
+            for (std::size_t a = 0; a < a_range_; ++a) {
+                // 讀取 activation 值；若是 uint8_t，則認為是 quantized 4-bit 需做 signed 轉換
+                P act_val;
+                if constexpr (std::is_same<ActivationType, uint8_t>::value) {
+                    uint8_t raw = act_row[a];
+                    // two's complement mapping for 4-bit
+                   act_val = static_cast<P>( raw < (weight_levels_/2) ? raw : raw - weight_levels_ );
+               } else {
+                    act_val = static_cast<P>(act_row[a]);
+                }
+                // 計算乘積
+
+               int64_t prod_int = static_cast<int64_t>(signed_w) * static_cast<int64_t>(act_val);
+                // 飽和處理
+                if (prod_int > std::numeric_limits<P>::max()) prod_int = std::numeric_limits<P>::max();
+                else if (prod_int < std::numeric_limits<P>::min()) prod_int = std::numeric_limits<P>::min();
+                row_ptr[a] = static_cast<P>(prod_int);
+            }
+            // padding 部分不必初始化
+        }
     }
-    inline ProductType operator()(W w, A a) const noexcept {
+
+    // 取得 weight-level w 的向量查表指標
+    inline const P* get_row(std::size_t w) const noexcept {
+        return &table_[w * padded_a_range_];
+    }
+
+    // 元素查表，保留舊接口
+    inline ProductType get(std::size_t w, std::size_t a) const noexcept {
+        return table_[w * padded_a_range_ + a];
+    }
+    inline ProductType operator()(std::size_t w, std::size_t a) const noexcept {
         return get(w, a);
     }
 
-    // ---- helpers ----
-    const ProductType* data()   const noexcept { return table_.data(); }
-    std::size_t        row_stride() const noexcept { return padded_a_range_; }
-    std::size_t        weight_range() const noexcept { return w_range_; }
-    std::size_t        activation_range() const noexcept { return a_range_; }
-    std::size_t lut_size_bytes() const noexcept { return table_.size() * sizeof(ProductType);}
+    // table 資料屬性
+    const P* data() const noexcept { return table_.data(); }
+    std::size_t row_stride() const noexcept { return padded_a_range_; }
+    std::size_t weight_levels() const noexcept { return weight_levels_; }
+    std::size_t activation_range() const noexcept { return a_range_; }
+    std::size_t lut_size_bytes() const noexcept { return table_.size() * sizeof(P); }
 
 private:
-    std::size_t w_range_, a_range_, padded_a_range_;
-    std::vector<ProductType, AlignedAllocator<ProductType,64>> table_;   // flat buffer (w * a_range + a)
+    std::size_t weight_levels_, a_range_, padded_a_range_;
+    std::vector<P, AlignedAllocator<P, 64>> table_;  // flat buffer (w * padded + a)
 };

--- a/src/quant_utils.hpp
+++ b/src/quant_utils.hpp
@@ -4,14 +4,25 @@
 #include <cstdint>
 
 // INT4 量化：fp16_val → uint8_t (低 4 bits)
-inline uint8_t quantize_int4(float fp16_val, float scale, int zero_point = 0) {
-    int q = static_cast<int>(std::round(fp16_val / scale)) + zero_point;
-    q = std::clamp(q, 0, 15);          // INT4 無號 0‥15
+inline uint8_t quantize_int4(float fp16_val, float scale, int zero_point = 8) {
+    // 先將值限制在有符號 int4 範圍內（考慮 scale）
+    float min_val = -8.0f * scale;
+    float max_val = 7.0f * scale;
+    float clamped_val = std::clamp(fp16_val, min_val, max_val);
+    
+    // 將值轉換為整數，並加上 zero_point
+    float scaled_val = clamped_val / scale;
+    int q = static_cast<int>(std::round(scaled_val)) + zero_point;
+    
+    // 確保結果在 0-15 範圍內
+    q = std::clamp(q, 0, 15);
     return static_cast<uint8_t>(q);
 }
 
 // INT4 反量化：uint8_t (低 4 bits) → float
-inline float dequantize_int4(uint8_t q, float scale, int zero_point = 0) {
+inline float dequantize_int4(uint8_t q, float scale, int zero_point = 8) {
+    // 將無符號值轉換為有符號值
     int qi = static_cast<int>(q) - zero_point;
+    // 轉換回浮點數
     return static_cast<float>(qi) * scale;
 }

--- a/tests/test_correctness.cpp
+++ b/tests/test_correctness.cpp
@@ -253,12 +253,17 @@ bool run_int4_fast_test(){
 // 7. Quantization/Dequantization test
 bool run_quant_dequant_test() {
     std::cout << "Running INT4 quant-dequant test...\n";
-    float scale = 0.25f;       // 假設
+    float scale = 1.0f;       // 假設
     bool pass = true;
-    for (float v : {0.0f, 1.0f, 2.25f, 3.5f}) {
+    // 測試有符號 int4 範圍 (-8 到 +7)
+    for (float v : {-8.0f, -4.0f, 0.0f, 4.0f, 7.0f}) {
         uint8_t q = quantize_int4(v, scale);
         float   d = dequantize_int4(q, scale);
-        if (std::abs(d - std::round(v/scale)*scale) > 1e-3f) pass = false;
+        if (std::abs(d - v) > 1e-3f) {
+            std::cout << "Failed at value " << v << ": quantized=" << (int)q 
+                      << ", dequantized=" << d << "\n";
+            pass = false;
+        }
     }
     std::cout << (pass ? "Quant-Dequant test PASS\n" : "FAIL\n");
     return pass;


### PR DESCRIPTION
This update refactors the lookup table implementation to support mixed-precision matrix multiplication, specifically INT4 × FP16 or FP32. The `ProductLookupTable` class has been extended to allow both scalar lookups and dynamic row-wise generation of lookup vectors based on activation matrix rows. This enables more efficient LUT-based computation without requiring runtime multiplications. The fast GEMM kernel is updated accordingly to rebuild the LUT for each activation row, improving cache locality and performance. Additionally, the original AVX2-specific code has been removed to simplify the implementation and improve readability. All relevant tests, including those involving INT4 and mixed-precision computation, pass successfully.
